### PR TITLE
Fixed:[MVD-06] Corrige campo de busca duplicado no bottom navigation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,7 +37,6 @@ class MyApp extends StatelessWidget {
               primary: AppColors.primaryColor,
               secondary: AppColors.secondaryColor,
               surface: AppColors.primaryBackgroundColor,
-              background: AppColors.secondaryBackgroundColor,
               error: AppColors.errorColor,
               onPrimary: AppColors.secondaryText,
               onSecondary: AppColors.secondaryText,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -83,7 +83,6 @@ class _MyHomePageState extends State<MyHomePage> {
       drawer: const NavBarMain(),
       body: Column(
         children: [
-          const SearchBarApp(),
           Expanded(
             child: _screens[_currentIndex],
           ),

--- a/lib/presenter/pages/main_screen.dart
+++ b/lib/presenter/pages/main_screen.dart
@@ -10,6 +10,7 @@ import '../bloc/series/series_event.dart';
 import '../bloc/series/series_state.dart';
 import '../widgets/home/banner_list.dart';
 import '../widgets/home/media_list.dart';
+import '../widgets/home/search_bar_app.dart';
 
 class MainScreen extends StatefulWidget {
   const MainScreen({super.key});
@@ -40,6 +41,10 @@ class _MainScreenState extends State<MainScreen> {
     return Scaffold(
       body: ListView(
         children: [
+          const Padding(
+            padding: EdgeInsets.symmetric(vertical: 16.0),
+            child: SearchBarApp(),
+          ),
           BlocBuilder<MovieBloc, MovieState>(
             bloc: _movieBloc,
             builder: (context, movieState) {


### PR DESCRIPTION
### Descrição

Este PR corrige bug ao clicar na busca de pesquisa no bottom navigation o componente estava sendo chamado novamente e visualmente aparecia duplicado. O componente Search foi movido para a screen main e removido a chamada duplicada da main, também foi adicionado um padding entre o search e a navBar.

- Antes -----------------> Depois
<img src="https://github.com/desenvolve06/r6_moovie_app/assets/63366380/8439111a-91b2-42d9-a85a-1e7fbd2e3072" width ="140" height="300">    <img src="https://github.com/desenvolve06/r6_moovie_app/assets/63366380/ea490a5c-845c-4081-a72a-a3935846c04d"  width ="140" height="300"> 

